### PR TITLE
Update fetching images and links from adult works

### DIFF
--- a/src/mandarake/scrape.js
+++ b/src/mandarake/scrape.js
@@ -66,12 +66,12 @@ const parseShop = (shopString, lang) => {
  */
 const parseSingleSearchResult = ($, lang) => (n, entry) => {
   // Whether this is an adult item.
-  const isAdult = $('.r18item', entry).length > 0
+  const isAdult = $('.r18mark', entry).length > 0
 
   // Adult items hide the link to the item's detail page.
   // Either generate the link from the item code, or take it from the <a> tag.
   const link = isAdult
-    ? mandarakeOrderURL($('.adult_link', entry).attr('id').trim())
+    ? $('img:not(.r18mark img)', entry).attr('src').trim()
     : parseLink($('.pic a', entry).attr('href'))
 
   // If this is an adult item, the image will be in a different place.


### PR DESCRIPTION
Mandarake changed the structure of the results page, causing mdrscr to wrongly fetch the urls for the thumbnails and links to adult works. This pull request updates the fetching to reflect those changes.

Before:
![image](https://user-images.githubusercontent.com/78220403/106297584-25bec900-6253-11eb-8809-e40d9d33d310.png)


After:
![imagen](https://user-images.githubusercontent.com/78220403/106297625-32dbb800-6253-11eb-8c96-f3a0bd47adeb.png)
